### PR TITLE
Add Telegram bot workflow with selectable GPT models

### DIFF
--- a/TelegramBot.json
+++ b/TelegramBot.json
@@ -1,0 +1,526 @@
+{
+  "name": "TelegramBot",
+  "nodes": [
+    {
+      "parameters": {
+        "updates": [
+          "message",
+          "callback_query"
+        ],
+        "additionalFields": {
+          "download": false,
+          "userIds": "6291098530"
+        }
+      },
+      "id": "4b728edd-3586-4edf-bb75-1c862163f160",
+      "name": "Telegram Message Trigger",
+      "type": "n8n-nodes-base.telegramTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -448,
+        96
+      ],
+      "webhookId": "55acc711-c248-4ac9-b6cd-e295c2d33f4b",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.callback_query }}",
+              "rightValue": "",
+              "operator": {
+                "type": "object",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        -224,
+        96
+      ],
+      "id": "9c39d674-d887-4898-94f2-5f85bdc5a6e3",
+      "name": "Is callback query"
+    },
+    {
+      "parameters": {
+        "functionCode": "const labels = {\n  'gpt-5': 'GPT-5',\n  'gpt-5-mini': 'GPT-5 Mini',\n  'gpt-5-nano': 'GPT-5 Nano',\n};\nconst staticData = this.getWorkflowStaticData('global');\nstaticData.modelByChat = staticData.modelByChat || {};\nreturn items.map(item => {\n  const data = item.json;\n  const callback = data.callback_query;\n  const chatId = callback?.message?.chat?.id;\n  if (chatId === undefined) {\n    return item;\n  }\n  const key = String(chatId);\n  const selection = callback.data || 'gpt-5-nano';\n  staticData.modelByChat[key] = selection;\n  const label = labels[selection] || selection;\n  data.chatId = chatId;\n  data.selectedModel = selection;\n  data.selectedModelLabel = label;\n  data.output = 'Модель ' + label + ' активирована.';\n  data.callbackQueryId = callback.id;\n  return item;\n});"
+      },
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -32,
+        -96
+      ],
+      "id": "0a7aaae6-7a8a-4feb-82ab-e245032e0cd4",
+      "name": "Handle Model Selection"
+    },
+    {
+      "parameters": {
+        "functionCode": "const staticData = this.getWorkflowStaticData('global');\nstaticData.modelByChat = staticData.modelByChat || {};\nconst labels = {\n  'gpt-5': 'GPT-5',\n  'gpt-5-mini': 'GPT-5 Mini',\n  'gpt-5-nano': 'GPT-5 Nano',\n};\nreturn items.map(item => {\n  const data = item.json;\n  const message = data.message;\n  const chatId = message?.chat?.id;\n  if (chatId !== undefined) {\n    const key = String(chatId);\n    if (!staticData.modelByChat[key]) {\n      staticData.modelByChat[key] = 'gpt-5-nano';\n    }\n    const model = staticData.modelByChat[key];\n    data.chatId = chatId;\n    data.selectedModel = model;\n    data.selectedModelLabel = labels[model] || model;\n  } else {\n    const model = data.selectedModel || 'gpt-5-nano';\n    data.selectedModel = model;\n    data.selectedModelLabel = labels[model] || model;\n  }\n  return item;\n});"
+      },
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -32,
+        96
+      ],
+      "id": "90dfa0c6-1eaf-4ab7-a7a4-7db04bafac50",
+      "name": "Prepare Chat Context"
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "fileId": "={{ $json.message.voice?.file_id || $json.message.audio?.file_id }}",
+        "additionalFields": {}
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        416,
+        0
+      ],
+      "id": "046bc1e5-24ec-405b-9090-35d402469d80",
+      "name": "Get a file",
+      "webhookId": "e0769871-efe3-49da-81a5-2f88a6fdd33f",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "voice-condition",
+              "leftValue": "={{ $json.message.voice }}",
+              "rightValue": "",
+              "operator": {
+                "type": "object",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "audio-condition",
+              "leftValue": "={{ $json.message.audio }}",
+              "rightValue": "",
+              "operator": {
+                "type": "object",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "or"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        224,
+        96
+      ],
+      "id": "acf2f95d-adc9-40f9-bfa3-eef2c342118c",
+      "name": "Check if Audio file"
+    },
+    {
+      "parameters": {
+        "resource": "audio",
+        "operation": "transcribe",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.openAi",
+      "typeVersion": 1.8,
+      "position": [
+        640,
+        0
+      ],
+      "id": "28ed47c0-4702-4888-bfbc-5b1ab96a0338",
+      "name": "Transcribe audio",
+      "credentials": {
+        "openAiApi": {
+          "id": "xFVXRoXzxkltJNgI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "eb912219-2436-4f04-8ffc-c1c20eb07344",
+              "name": "text",
+              "value": "={{ $json.message.text }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        416,
+        192
+      ],
+      "id": "b78d3180-5b1f-45da-a8a3-af4205bab897",
+      "name": "Set field"
+    },
+    {
+      "parameters": {
+        "sessionIdType": "customKey",
+        "sessionKey": "={{ $('Prepare Chat Context').item.json.chatId }}",
+        "contextWindowLength": 10
+      },
+      "id": "ae110820-ee23-4b33-9def-e8678c8ae84f",
+      "name": "Memory",
+      "type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
+      "typeVersion": 1.3,
+      "position": [
+        1024,
+        384
+      ]
+    },
+    {
+      "parameters": {
+        "model": {
+          "__rl": true,
+          "value": "={{ $('Prepare Chat Context').item.json.selectedModel || 'gpt-5-nano' }}",
+          "mode": "list",
+          "cachedResultName": "={{ $('Prepare Chat Context').item.json.selectedModelLabel || $('Prepare Chat Context').item.json.selectedModel || 'gpt-5-nano' }}"
+        },
+        "options": {}
+      },
+      "id": "56a466c9-793c-4736-a09c-201ed39d483f",
+      "name": "Model",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1.2,
+      "position": [
+        768,
+        384
+      ],
+      "credentials": {
+        "openAiApi": {
+          "id": "xFVXRoXzxkltJNgI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "={{ $json.text || ($json.data && $json.data.text) || $json.message.text }}",
+        "options": {
+          "systemMessage": "=# РОЛЬ\n\nТы — AI-агент по имени Ava.\n\nТвоя задача — координировать работу между различными агентами и инструментами, а затем формировать дружелюбный и понятный ответ пользователю.\n\nТы никогда не пишешь письма, не создаёшь контакты, не создаёшь контент, не добавляешь события в календарь и не делаешь резюме самостоятельно. \nТвоя работа — вызывать нужные инструменты и агентов в правильной последовательности.\n\nВсегда думай о порядке действий. Некоторые инструменты сначала требуют вызвать другой инструмент, чтобы получить нужные данные для передачи дальше.\n\n\n# ИНСТРУМЕНТЫ\n\n- Google Search\n\n\n# ДОПОЛНИТЕЛЬНАЯ ИНФОРМАЦИЯ\n\n- Ты общаешься с пользователем по имени Konstantin.\n- Текущая дата и время: {{ $now.toString() }}\n- Локация: Бёнинген, Нидерланды.\n- Часовой пояс: CET (Europe/Amsterdam).\n- Отвечай на том языке, на котором задан вопрос:\n  - если вопрос на русском — отвечай по-русски,\n  - если вопрос на нидерландском — отвечай по-нидерландски.\n\n\n# ПРАВИЛА\n\n1. Никогда не выполняй задачи вручную — всегда используй подходящий инструмент.\n2. Если требуется уточнение, задавай пользователю уточняющий вопрос.\n3. При поиске в интернете формируй короткие и точные запросы.\n4. Будь дружелюбным и вежливым в ответах.\n5. Если вопрос выходит за рамки инструментов, отвечай как умный собеседник: помогай с фактами, идеями, советами.\n6. Добавляй полезные детали, которые могут быть интересны пользователю (новости, погода, тренды), если это уместно.\n"
+        }
+      },
+      "id": "0f315e84-5f5e-4fb1-bed8-e78808f2d9f5",
+      "name": "Assistant Agent",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 2.2,
+      "position": [
+        1024,
+        96
+      ]
+    },
+    {
+      "parameters": {
+        "chatId": "={{ $json.chatId || $('Prepare Chat Context').item.json.chatId || $('Telegram Message Trigger').first().json.callback_query?.message?.chat?.id || $('Telegram Message Trigger').first().json.message?.chat?.id }}",
+        "text": "={{ $json.output }}",
+        "replyMarkup": "inlineKeyboard",
+        "inlineKeyboard": {
+          "rows": [
+            {
+              "row": {
+                "buttons": [
+                  {
+                    "text": "GPT-5",
+                    "additionalFields": {
+                      "callback_data": "gpt-5"
+                    }
+                  },
+                  {
+                    "text": "Mini",
+                    "additionalFields": {
+                      "callback_data": "gpt-5-mini"
+                    }
+                  },
+                  {
+                    "text": "Nano",
+                    "additionalFields": {
+                      "callback_data": "gpt-5-nano"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "additionalFields": {}
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        1376,
+        96
+      ],
+      "id": "3133ab2a-6fcd-4227-a135-3f9558647f0d",
+      "name": "Reply in Telegram",
+      "webhookId": "b96b7a41-9806-455f-b72e-00aa638eda71",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "answerCallbackQuery",
+        "callbackQueryId": "={{ $json.callbackQueryId || $json.callback_query.id }}",
+        "additionalFields": {
+          "text": "={{ $json.selectedModelLabel ? 'Выбрана модель ' + $json.selectedModelLabel : '' }}",
+          "showAlert": false
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        256,
+        -96
+      ],
+      "id": "6a82f19d-595b-47f6-b2a4-0283c023e6e0",
+      "name": "Answer Callback Query",
+      "webhookId": "d3d61079-6c63-4b9d-8986-1ac66f49c41b",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "options": {
+          "gl": "nl",
+          "device": "desktop",
+          "no_cache": false,
+          "google_domain": "google.com",
+          "hl": "nl"
+        }
+      },
+      "type": "@n8n/n8n-nodes-langchain.toolSerpApi",
+      "typeVersion": 1,
+      "position": [
+        1392,
+        384
+      ],
+      "id": "441e7322-8534-425f-abaf-63d4e01a1fb1",
+      "name": "Google Search",
+      "credentials": {
+        "serpApi": {
+          "id": "qZbZv77Clxbhdatj",
+          "name": "SerpAPI account"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Telegram Message Trigger": {
+      "main": [
+        [
+          {
+            "node": "Is callback query",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is callback query": {
+      "main": [
+        [
+          {
+            "node": "Handle Model Selection",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Chat Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Chat Context": {
+      "main": [
+        [
+          {
+            "node": "Check if Audio file",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check if Audio file": {
+      "main": [
+        [
+          {
+            "node": "Get a file",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set field",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get a file": {
+      "main": [
+        [
+          {
+            "node": "Transcribe audio",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Transcribe audio": {
+      "main": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set field": {
+      "main": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Handle Model Selection": {
+      "main": [
+        [
+          {
+            "node": "Answer Callback Query",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Reply in Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Assistant Agent": {
+      "main": [
+        [
+          {
+            "node": "Reply in Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Memory": {
+      "ai_memory": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "ai_memory",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Search": {
+      "ai_tool": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "ai_tool",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "6ce9538a-d5b0-4d66-951f-9d9e4c25863b",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "cbcdbe900921b2482860818f3c4684b647fa895db629840c91a2160cfc9c9ff0"
+  },
+  "id": "Aga3B8C6htZiy6xG",
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- add handling for Telegram callback queries so users can switch between GPT-5, GPT-5 Mini, and GPT-5 Nano
- persist each chat's selected model and use it when invoking the assistant workflow
- update the Telegram reply flow to show the inline keyboard and confirm the active model

## Testing
- python -m json.tool TelegramBot.json

------
https://chatgpt.com/codex/tasks/task_b_68c9bcdf3888832fb4a04402b774353e