### PR TITLE
Add Telegram bot workflow with model selection

### DIFF
--- a/n8n/TelegramBot.json
+++ b/n8n/TelegramBot.json
@@ -1,0 +1,489 @@
+{
+  "name": "TelegramBot",
+  "nodes": [
+    {
+      "parameters": {
+        "updates": [
+          "message",
+          "callback_query"
+        ],
+        "additionalFields": {
+          "download": false,
+          "userIds": "6291098530"
+        }
+      },
+      "id": "4b728edd-3586-4edf-bb75-1c862163f160",
+      "name": "Telegram Message Trigger",
+      "type": "n8n-nodes-base.telegramTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -560,
+        96
+      ],
+      "webhookId": "55acc711-c248-4ac9-b6cd-e295c2d33f4b",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.callback_query }}",
+              "rightValue": "",
+              "operator": {
+                "type": "object",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        -320,
+        96
+      ],
+      "id": "c250da95-ec4c-4f69-a4ec-69d7c0d52701",
+      "name": "Is Callback Query"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "voice-condition",
+              "leftValue": "={{ $json.message.voice }}",
+              "rightValue": "",
+              "operator": {
+                "type": "object",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "audio-condition",
+              "leftValue": "={{ $json.message.audio }}",
+              "rightValue": "",
+              "operator": {
+                "type": "object",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "or"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        -64,
+        96
+      ],
+      "id": "acf2f95d-adc9-40f9-bfa3-eef2c342118c",
+      "name": "Check if Audio file"
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "fileId": "={{ $json.message.voice?.file_id || $json.message.audio?.file_id }}",
+        "additionalFields": {}
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        160,
+        0
+      ],
+      "id": "046bc1e5-24ec-405b-9090-35d402469d80",
+      "name": "Get a file",
+      "webhookId": "e0769871-efe3-49da-81a5-2f88a6fdd33f",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "audio",
+        "operation": "transcribe",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.openAi",
+      "typeVersion": 1.8,
+      "position": [
+        384,
+        0
+      ],
+      "id": "28ed47c0-4702-4888-bfbc-5b1ab96a0338",
+      "name": "Transcribe audio",
+      "credentials": {
+        "openAiApi": {
+          "id": "xFVXRoXzxkltJNgI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "eb912219-2436-4f04-8ffc-c1c20eb07344",
+              "name": "text",
+              "value": "={{ $json.message.text }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        160,
+        192
+      ],
+      "id": "b78d3180-5b1f-45da-a8a3-af4205bab897",
+      "name": "Set field"
+    },
+    {
+      "parameters": {
+        "functionCode": "const staticData = this.getWorkflowStaticData('global');\nif (!staticData.modelSelections) {\n  staticData.modelSelections = {};\n}\nconst triggerItem = $items('Telegram Message Trigger', 0, 0).json;\nconst chatId = $json.chatId || $json.message?.chat?.id || triggerItem.message?.chat?.id || triggerItem.callback_query?.message?.chat?.id;\nif (!chatId) {\n  throw new Error('Не удалось определить идентификатор чата.');\n}\nconst selectedModel = staticData.modelSelections[chatId] || 'gpt-5-nano';\nreturn {\n  ...$json,\n  chatId,\n  selectedModel\n};"
+      },
+      "id": "fa96807d-69c2-4abb-8079-6599c98bc7e1",
+      "name": "Load Selected Model",
+      "type": "n8n-nodes-base.functionItem",
+      "typeVersion": 1,
+      "position": [
+        608,
+        96
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const staticData = this.getWorkflowStaticData('global');\nif (!staticData.modelSelections) {\n  staticData.modelSelections = {};\n}\nconst callbackData = $json.callback_query?.data;\nconst chatId = $json.callback_query?.message?.chat?.id;\nconst modelMap = {\n  'gpt-5': 'GPT-5',\n  'gpt-5-mini': 'GPT-5 Mini',\n  'gpt-5-nano': 'GPT-5 Nano'\n};\nif (!chatId) {\n  return {\n    ...$json,\n    output: 'Не удалось определить чат для переключения модели.'\n  };\n}\nif (!modelMap[callbackData]) {\n  const currentModel = staticData.modelSelections[chatId] || 'gpt-5-nano';\n  return {\n    ...$json,\n    chatId,\n    selectedModel: currentModel,\n    output: 'Неизвестная модель. Оставляем текущие настройки.'\n  };\n}\nstaticData.modelSelections[chatId] = callbackData;\nreturn {\n  ...$json,\n  chatId,\n  selectedModel: callbackData,\n  output: `✅ Модель переключена на ${modelMap[callbackData]}.`\n};"
+      },
+      "id": "6b4f4c8b-1b1d-4f20-98e9-7fb1f7edb3c5",
+      "name": "Update Model Selection",
+      "type": "n8n-nodes-base.functionItem",
+      "typeVersion": 1,
+      "position": [
+        -64,
+        -96
+      ]
+    },
+    {
+      "parameters": {
+        "model": "={{ $('Load Selected Model').item.json.selectedModel || 'gpt-5-nano' }}",
+        "options": {}
+      },
+      "id": "56a466c9-793c-4736-a09c-201ed39d483f",
+      "name": "Model",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1.2,
+      "position": [
+        608,
+        384
+      ],
+      "credentials": {
+        "openAiApi": {
+          "id": "xFVXRoXzxkltJNgI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "sessionIdType": "customKey",
+        "sessionKey": "={{ $('Telegram Message Trigger').first().json.message.chat.id }}",
+        "contextWindowLength": 10
+      },
+      "id": "ae110820-ee23-4b33-9def-e8678c8ae84f",
+      "name": "Memory",
+      "type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
+      "typeVersion": 1.3,
+      "position": [
+        832,
+        384
+      ]
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "={{ $json.text || ($json.data && $json.data.text) || $json.message.text }}",
+        "options": {
+          "systemMessage": "=# РОЛЬ\n\nТы — AI-агент по имени Ava.\n\nТвоя задача — координировать работу между различными агентами и инструментами, а затем формировать дружелюбный и понятный ответ пользователю.\n\nТы никогда не пишешь письма, не создаёшь контакты, не создаёшь контент, не добавляешь события в календарь и не делаешь резюме самостоятельно. \nТвоя работа — вызывать нужные инструменты и агентов в правильной последовательности.\n\nВсегда думай о порядке действий. Некоторые инструменты сначала требуют вызвать другой инструмент, чтобы получить нужные данные для передачи дальше.\n\n\n# ИНСТРУМЕНТЫ\n\n- Google Search\n\n\n# ДОПОЛНИТЕЛЬНАЯ ИНФОРМАЦИЯ\n\n- Ты общаешься с пользователем по имени Konstantin.\n- Текущая дата и время: {{ $now.toString() }}\n- Локация: Бёнинген, Нидерланды.\n- Часовой пояс: CET (Europe/Amsterdam).\n- Отвечай на том языке, на котором задан вопрос:\n  - если вопрос на русском — отвечай по-русски,\n  - если вопрос на нидерландском — отвечай по-нидерландски.\n\n\n# ПРАВИЛА\n\n1. Никогда не выполняй задачи вручную — всегда используй подходящий инструмент.\n2. Если требуется уточнение, задавай пользователю уточняющий вопрос.\n3. При поиске в интернете формируй короткие и точные запросы.\n4. Будь дружелюбным и вежливым в ответах.\n5. Если вопрос выходит за рамки инструментов, отвечай как умный собеседник: помогай с фактами, идеями, советами.\n6. Добавляй полезные детали, которые могут быть интересны пользователю (новости, погода, тренды), если это уместно.\n"
+        }
+      },
+      "id": "0f315e84-5f5e-4fb1-bed8-e78808f2d9f5",
+      "name": "Assistant Agent",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 2.2,
+      "position": [
+        832,
+        96
+      ]
+    },
+    {
+      "parameters": {
+        "chatId": "={{ $json.chatId || $json.message?.chat?.id || $json.callback_query?.message?.chat?.id }}",
+        "text": "={{ $json.output }}",
+        "replyMarkup": "inlineKeyboard",
+        "inlineKeyboard": {
+          "rows": [
+            {
+              "row": {
+                "buttons": [
+                  {
+                    "text": "GPT-5",
+                    "additionalFields": {
+                      "callback_data": "gpt-5"
+                    }
+                  },
+                  {
+                    "text": "GPT-mini",
+                    "additionalFields": {
+                      "callback_data": "gpt-5-mini"
+                    }
+                  },
+                  {
+                    "text": "GPT-nano",
+                    "additionalFields": {
+                      "callback_data": "gpt-5-nano"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "additionalFields": {}
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        1088,
+        96
+      ],
+      "id": "3133ab2a-6fcd-4227-a135-3f9558647f0d",
+      "name": "Reply in Telegram",
+      "webhookId": "b96b7a41-9806-455f-b72e-00aa638eda71",
+      "credentials": {
+        "telegramApi": {
+          "id": "gg9kTjcFuE3xXuob",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "options": {
+          "gl": "nl",
+          "device": "desktop",
+          "no_cache": false,
+          "google_domain": "google.com",
+          "hl": "nl"
+        }
+      },
+      "type": "@n8n/n8n-nodes-langchain.toolSerpApi",
+      "typeVersion": 1,
+      "position": [
+        1088,
+        384
+      ],
+      "id": "441e7322-8534-425f-abaf-63d4e01a1fb1",
+      "name": "Google Search",
+      "credentials": {
+        "serpApi": {
+          "id": "qZbZv77Clxbhdatj",
+          "name": "SerpAPI account"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Telegram Message Trigger": {
+      "main": [
+        [
+          {
+            "node": "Is Callback Query",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Callback Query": {
+      "main": [
+        [
+          {
+            "node": "Update Model Selection",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Check if Audio file",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check if Audio file": {
+      "main": [
+        [
+          {
+            "node": "Get a file",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Set field",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get a file": {
+      "main": [
+        [
+          {
+            "node": "Transcribe audio",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Transcribe audio": {
+      "main": [
+        [
+          {
+            "node": "Load Selected Model",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set field": {
+      "main": [
+        [
+          {
+            "node": "Load Selected Model",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Load Selected Model": {
+      "main": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Model Selection": {
+      "main": [
+        [
+          {
+            "node": "Reply in Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Memory": {
+      "ai_memory": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "ai_memory",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Assistant Agent": {
+      "main": [
+        [
+          {
+            "node": "Reply in Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Search": {
+      "ai_tool": [
+        [
+          {
+            "node": "Assistant Agent",
+            "type": "ai_tool",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "6ce9538a-d5b0-4d66-951f-9d9e4c25863b",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "cbcdbe900921b2482860818f3c4684b647fa895db629840c91a2160cfc9c9ff0"
+  },
+  "id": "Aga3B8C6htZiy6xG",
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- add the Telegram workflow template for n8n with inline buttons for GPT-5, GPT-mini, and GPT-nano
- persist the selected model per chat with a default of GPT-5 Nano and reuse it for subsequent requests
- route callback queries separately from text/audio handling and load the chosen model before invoking the assistant

## Testing
- jq . n8n/TelegramBot.json

------
https://chatgpt.com/codex/tasks/task_b_68c9bcdf3888832fb4a04402b774353e